### PR TITLE
Fix issue #32 - separate the keyboard shortcuts in some config file

### DIFF
--- a/keybindings.json
+++ b/keybindings.json
@@ -1,5 +1,5 @@
 [
-	["^N", "sort_by_memory", "Memory Sort"],
+    ["^N", "sort_by_memory", "Memory Sort"],
     ["^T", "sort_by_time", "Time Sort"],
     ["^K", "kill_process", "Kill"],
     ["^Q", "quit", "Quit"],

--- a/keybindings.json
+++ b/keybindings.json
@@ -1,0 +1,10 @@
+[
+	["^N", "sort_by_memory", "Memory Sort"],
+    ["^T", "sort_by_time", "Time Sort"],
+    ["^K", "kill_process", "Kill"],
+    ["^Q", "quit", "Quit"],
+    ["^R", "reset", "Reset"],
+    ["^L", "show_detailed_process_info", "Process Info"],
+    ["^F", "do_process_filtering_work", "Filter"],
+    ["g", "", "Top"]
+]

--- a/ptop/interfaces/GUI.py
+++ b/ptop/interfaces/GUI.py
@@ -142,17 +142,17 @@ class CustomMultiLineAction(npyscreen.MultiLineAction):
         methods = self._get_class_methods()
 
         # we extract the methods by name and assign them to the key
-        for b in bindings:
-            if b[1]:
-                keybindings[b[0]] = methods["_" + b[1]]
-            shortcut_keys[b[0]] = b[2]
+        for binding in bindings:
+            if binding[1]:
+                keybindings[binding[0]] = methods["_" + binding[1]]
+            shortcut_keys[binding[0]] = binding[2]
 
         return keybindings
 
     def _get_class_methods(self):
         methods = {}
-        for m in inspect.getmembers(self, inspect.ismethod):
-            methods[m[0]] = m[1]
+        for method in inspect.getmembers(self, inspect.ismethod):
+            methods[method[0]] = method[1]
         return methods
 
     def _get_selected_process_pid(self):


### PR DESCRIPTION
Hi, I tried to separate the shortcuts to a JSON file.
The JSON looks like this:

```
[
    ["^N", "sort_by_memory", "Memory Sort"],
    ["^T", "sort_by_time", "Time Sort"],
    ["^K", "kill_process", "Kill"],
    ["^Q", "quit", "Quit"],
    ["^R", "reset", "Reset"],
    ["^L", "show_detailed_process_info", "Process Info"],
    ["^F", "do_process_filtering_work", "Filter"],
    ["g", "", "Top"]
]
```

The first element is the shortcut, the second is the name of the method that is called and third is the name showed to the user.
I know letting the user write which method should be called should be avoided but I haven't found any other way to implement this.

Another thing, I used a global variable to save the shortcut key and its name between classes. I've seen you using global variables so I think it should be alright to you.
Another way to do this, without using a global variable, is to read the file twice.
Let me know what you think about this.

This is my first PR ever to an OS project, so I apologize if I did something wrong. Thanks :)